### PR TITLE
Updated me.grantland:autofittextview version

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     compile 'com.android.support:recyclerview-v7:23.0.1'
     compile 'com.android.support:design:23.0.1'
     compile 'com.android.support:cardview-v7:23.1.0'
-    compile 'me.grantland:autofittextview:0.2.0'
+    compile 'me.grantland:autofittextview:0.2.1'
     compile 'com.bartoszlipinski:viewpropertyobjectanimator:1.2.0'
 }
 


### PR DESCRIPTION
In their latest release they removed allowBackup attribute from manifest which was causing troubles in applications that disabled auto backup.
