### PR TITLE
Fix ArrayIndexOutOfBoundsException 

### DIFF
--- a/library/src/main/java/com/arlib/floatingsearchview/suggestions/SearchSuggestionsAdapter.java
+++ b/library/src/main/java/com/arlib/floatingsearchview/suggestions/SearchSuggestionsAdapter.java
@@ -101,8 +101,10 @@ public class SearchSuggestionsAdapter extends RecyclerView.Adapter<RecyclerView.
                 @Override
                 public void onClick(View v) {
 
-                    if (mListener != null)
-                        mListener.onItemClicked(getAdapterPosition());
+                    int adapterPosition = getAdapterPosition();
+                    if (mListener != null && adapterPosition != RecyclerView.NO_POSITION) {
+                        mListener.onItemClicked(adapterPosition);
+                    }
                 }
             });
         }


### PR DESCRIPTION
This exception is raised when user clicks on item that is not available anymore because it was removed meanwhile.
