### PR TITLE
fix issue: #230

### DIFF
--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -37,5 +37,8 @@
         <attr name="floatingSearch_dividerColor" format="color"/>
         <attr name="floatingSearch_dimBackground" format="boolean"/>
         <attr name="floatingSearch_suggestionRightIconColor" format="color"/>
+        <!-- skip-save-state : If Set To True, Skip onSaveInstanceState(); -->
+        <attr name="floatingSearch_skipSaveState" format="boolean"/>
+        <!-- skip-save-state  -->
     </declare-styleable>
 </resources>


### PR DESCRIPTION
Fix https://github.com/arimorty/floatingsearchview/issues/230
in breaf: i add a feature for some cases that application have multiple fragment and developer dont want to create a new fragment every time.he just want use old fragment and load it.
this PR create a boolean attribute called:
`app:floatingSearch_skipSaveState="boolean"`
and this is defeault set to false.(for backward compatibility).
if anybody like to skip onRestoreInstanceState() method and use old view, he must set this property **true**.
regards.