### PR TITLE
Dismiss search on touch suggestions list margins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,8 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.0'
 
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
+
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,4 +1,7 @@
 apply plugin: 'com.android.library'
+apply plugin: 'com.github.dcendents.android-maven'
+
+group='com.github.arimorty'
 
 android {
     compileSdkVersion 25

--- a/library/src/main/java/com/arlib/floatingsearchview/FloatingSearchView.java
+++ b/library/src/main/java/com/arlib/floatingsearchview/FloatingSearchView.java
@@ -77,7 +77,6 @@ import com.bartoszlipinski.viewpropertyobjectanimator.ViewPropertyObjectAnimator
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -1123,7 +1122,7 @@ public class FloatingSearchView extends FrameLayout {
     public void setDismissOnOutsideClick(boolean enable) {
 
         mDismissOnOutsideTouch = enable;
-        mSuggestionsSection.setOnTouchListener(new OnTouchListener() {
+        setOnTouchListener(new OnTouchListener() {
             @Override
             public boolean onTouch(View v, MotionEvent event) {
 
@@ -1523,7 +1522,7 @@ public class FloatingSearchView extends FrameLayout {
 
         //if we don't have focus, we want to allow the client's views below our invisible
         //screen-covering view to handle touches
-        mSuggestionsSection.setEnabled(focused);
+        setEnabled(focused);
     }
 
     private void changeIcon(ImageView imageView, Drawable newIcon, boolean withAnim) {

--- a/library/src/main/java/com/arlib/floatingsearchview/FloatingSearchView.java
+++ b/library/src/main/java/com/arlib/floatingsearchview/FloatingSearchView.java
@@ -438,7 +438,7 @@ public class FloatingSearchView extends FrameLayout {
 
     private void setupViews(AttributeSet attrs) {
 
-        mSuggestionsSection.setEnabled(false);
+        setEnabled(false);
 
         if (attrs != null) {
             applyXmlAttributes(attrs);
@@ -1869,7 +1869,7 @@ public class FloatingSearchView extends FrameLayout {
         setCloseSearchOnKeyboardDismiss(savedState.dismissOnSoftKeyboardDismiss);
         setDismissFocusOnItemSelection(savedState.dismissFocusOnSuggestionItemClick);
 
-        mSuggestionsSection.setEnabled(mIsFocused);
+        setEnabled(mIsFocused);
         if (mIsFocused) {
 
             mBackgroundDrawable.setAlpha(BACKGROUND_DRAWABLE_ALPHA_SEARCH_FOCUSED);


### PR DESCRIPTION
Hi to all 🎉 

I've fixed an issue where touch is propagated below floating search views when it's focused.

### The bug

I've checked the issue in the sample app by removing the 5dp margins to the `search_results_list` in `fragment_sliding_search_results_example_fragment.xml`. Then you can see that this bug appears:

![wrong_scroll](https://user-images.githubusercontent.com/3925897/28323450-2a09c1aa-6bd9-11e7-9d62-71deb9dbe8a8.gif)

### The fix

To avoid this, I've changed the touch listener to dismiss the search from `mSuggestionsSection` to the `FloatingSearchView` itself, because it occupies the whole screen.

Now it works well

![good_scroll](https://user-images.githubusercontent.com/3925897/28323590-9305ae08-6bd9-11e7-9d0d-099e3923ae26.gif)