### PR TITLE
Fix reversed suggestions

### DIFF
--- a/library/src/main/java/com/arlib/floatingsearchview/FloatingSearchView.java
+++ b/library/src/main/java/com/arlib/floatingsearchview/FloatingSearchView.java
@@ -77,7 +77,6 @@ import com.bartoszlipinski.viewpropertyobjectanimator.ViewPropertyObjectAnimator
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -200,6 +199,7 @@ public class FloatingSearchView extends FrameLayout {
     private OnSuggestionsListHeightChanged mOnSuggestionsListHeightChanged;
     private long mSuggestionSectionAnimDuration;
     private OnClearSearchActionListener mOnClearSearchActionListener;
+    private ViewTreeObserver.OnGlobalLayoutListener mOnGlobalLayoutListener;
 
     //An interface for implementing a listener that will get notified when the suggestions
     //section's height is set. This is to be used internally only.
@@ -1345,8 +1345,11 @@ public class FloatingSearchView extends FrameLayout {
 
     private void swapSuggestions(final List<? extends SearchSuggestion> newSearchSuggestions,
                                  final boolean withAnim) {
-
-        mSuggestionsList.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
+        // Prevent calling twice for single swap
+        if (mOnGlobalLayoutListener != null) {
+            Util.removeGlobalLayoutObserver(mSuggestionsList, mOnGlobalLayoutListener);
+        }
+        mOnGlobalLayoutListener = new ViewTreeObserver.OnGlobalLayoutListener() {
             @Override
             public void onGlobalLayout() {
                 Util.removeGlobalLayoutObserver(mSuggestionsList, this);
@@ -1362,7 +1365,9 @@ public class FloatingSearchView extends FrameLayout {
                 }
                 mSuggestionsList.setAlpha(1);
             }
-        });
+        };
+        mSuggestionsList.getViewTreeObserver().addOnGlobalLayoutListener(mOnGlobalLayoutListener);
+
         mSuggestionsList.setAdapter(mSuggestionsAdapter);//workaround to avoid list retaining scroll pos
         mSuggestionsList.setAlpha(0);
         mSuggestionsAdapter.swapData(newSearchSuggestions);


### PR DESCRIPTION
Hi again 🎉 

I've fixed that if `swapSuggestions` is called twice in a row, then the suggestions are displayed incorrectly.

### The problem
`OnGlobalLayoutListener` is called twice for single suggestion swap if we call `swapSuggestion` in the same frame. The problem is that the second time we call `swapSuggestion`, `OnGlobalLayoutListener` has still not being called, so it ends up calling it twice (or many times).

### The solution
Instead of removing the listener when it's processed, we remove it every time we try to swap suggestions.

----
# Test
To test this problem, I've called the `swapSuggestions` twice in a row:

```
mSearchView.swapSuggestions(someSuggestions);
mSearchView.swapSuggestions(someOtherSuggestions);
```

### Before the fix

![incorrect_swap](https://user-images.githubusercontent.com/3925897/28365015-1bce575a-6c87-11e7-93fa-683c7180ec59.gif)

### After the fix

![correct_swap](https://user-images.githubusercontent.com/3925897/28365018-1cdbbb42-6c87-11e7-9e83-f41e1fa98aae.gif)
