### PR TITLE
Wrong suggestions order on restore instance state

### DIFF
--- a/library/src/main/java/com/arlib/floatingsearchview/FloatingSearchView.java
+++ b/library/src/main/java/com/arlib/floatingsearchview/FloatingSearchView.java
@@ -1814,7 +1814,8 @@ public class FloatingSearchView extends FrameLayout {
 
         savedState.suggestions = mSuggestionsAdapter.getDataSet();
         if (mSuggestionsAdapter.isReversed()) {
-            Collections.reverse(savedState.suggestions);
+            // Reverse a copy of the suggestions to avoid altering original list
+            Collections.reverse(new ArrayList<>(savedState.suggestions));
         }
 
         savedState.isFocused = mIsFocused;

--- a/library/src/main/java/com/arlib/floatingsearchview/FloatingSearchView.java
+++ b/library/src/main/java/com/arlib/floatingsearchview/FloatingSearchView.java
@@ -1811,7 +1811,12 @@ public class FloatingSearchView extends FrameLayout {
     public Parcelable onSaveInstanceState() {
         Parcelable superState = super.onSaveInstanceState();
         SavedState savedState = new SavedState(superState);
+
         savedState.suggestions = mSuggestionsAdapter.getDataSet();
+        if (mSuggestionsAdapter.isReversed()) {
+            Collections.reverse(savedState.suggestions);
+        }
+
         savedState.isFocused = mIsFocused;
         savedState.query = getQuery();
         savedState.suggestionTextSize = mSuggestionsTextSizePx;

--- a/library/src/main/java/com/arlib/floatingsearchview/suggestions/SearchSuggestionsAdapter.java
+++ b/library/src/main/java/com/arlib/floatingsearchview/suggestions/SearchSuggestionsAdapter.java
@@ -50,6 +50,7 @@ public class SearchSuggestionsAdapter extends RecyclerView.Adapter<RecyclerView.
     private int mBodyTextSizePx;
     private int mTextColor = -1;
     private int mRightIconColor = -1;
+    private boolean mIsResultsReversed = false;
 
     public interface OnBindSuggestionCallback {
 
@@ -123,6 +124,7 @@ public class SearchSuggestionsAdapter extends RecyclerView.Adapter<RecyclerView.
     }
 
     public void swapData(List<? extends SearchSuggestion> searchSuggestions) {
+        mIsResultsReversed = false;
         mSearchSuggestions = searchSuggestions;
         notifyDataSetChanged();
     }
@@ -240,7 +242,12 @@ public class SearchSuggestionsAdapter extends RecyclerView.Adapter<RecyclerView.
     }
 
     public void reverseList() {
+        mIsResultsReversed = !mIsResultsReversed;
         Collections.reverse(mSearchSuggestions);
         notifyDataSetChanged();
+    }
+
+    public boolean isReversed() {
+        return mIsResultsReversed;
     }
 }


### PR DESCRIPTION
Hi again 🎉 

I've found another problem with suggestions order when the suggestions list has been reversed and the view is restored from instance state.

### The problem
When the suggestions list is reversed and `onSaveInstanceState` is called, the suggestions list is saved reversed, not as it has been delivered to the `FloatingSearchView` through `swapSuggestions`. Then, when the view is restored from instance state `restoreFromInstanceState`, the suggestions are reversed, and when they are delivered again to `swapSuggestions` the list is reversed again, so we end up with the results in reversed order.

### The solution
If the suggestions list is reversed, then we reverse it again before saving on `onSaveInstanceState`.

---
# Test

To test this, I had to change in `MainActivity:51` from:

`        showFragment(new SlidingSearchResultsExampleFragment());`

to: 

```
        if (savedInstanceState == null) {
            showFragment(new SlidingSearchResultsExampleFragment());
        }
```

so the fragment is not created every time the Activity is destroyed if we are recovering from a previous instance. You should activate this option also in the developer settings to check restoring from instance state:

![dont_keep_activities](https://user-images.githubusercontent.com/3925897/28373738-5967c1f2-6ca3-11e7-9054-a25f89b0a590.png)

### Before the fix
![wrong_order](https://user-images.githubusercontent.com/3925897/28373981-b85ca90c-6ca3-11e7-84e4-14c1b9ed497a.gif)

### After the fix
![correct_order](https://user-images.githubusercontent.com/3925897/28373979-b7b0fac6-6ca3-11e7-8d69-e31a5b6e2a94.gif)


