### PR TITLE
Wrong calculation of suggestions list height

### DIFF
--- a/library/src/main/java/com/arlib/floatingsearchview/FloatingSearchView.java
+++ b/library/src/main/java/com/arlib/floatingsearchview/FloatingSearchView.java
@@ -77,7 +77,6 @@ import com.bartoszlipinski.viewpropertyobjectanimator.ViewPropertyObjectAnimator
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -1425,9 +1424,15 @@ public class FloatingSearchView extends FrameLayout {
     //returns the cumulative height that the current suggestion items take up or the given max if the
     //results is >= max. The max option allows us to avoid doing unnecessary and potentially long calculations.
     private int calculateSuggestionItemsHeight(List<? extends SearchSuggestion> suggestions, int max) {
+        if (mSuggestionsList.getChildCount() < suggestions.size()) {
+            return max;
+        }
 
         //todo
         // 'i < suggestions.size()' in the below 'for' seems unneeded, investigate if there is a use for it.
+        // NOTE ebosch: 20/07/2017 I think 'i < suggestions.size()' might be here to avoid
+        // calculating more children than the number of current suggestions. But if this happens
+        // might be that mSuggestionsList has not already been populated with new suggestions items.
         int visibleItemsHeight = 0;
         for (int i = 0; i < suggestions.size() && i < mSuggestionsList.getChildCount(); i++) {
             visibleItemsHeight += mSuggestionsList.getChildAt(i).getHeight();


### PR DESCRIPTION
Hi again 🎉 

I've fixed another issue that causes the suggestions list to be positioned not in the first item when suggestions are swapped.

### The problem

The problem was that sometimes the suggestions RecyclerView create fewer items than the number of swapped suggestions, but it says that the items do not fill all the height suggestions. This is impossible because suggestions could not fill all the suggestions list view only if he can draw all swapped suggestions. So, when some suggestions are not drawn, is a signal that there are more suggestions than what suggestions list could fit, and this means that the suggestions list height fill all the view height.

----
# Test

To test this, I've used an emulator with 4,5'' and 480x854 resolution. Also, I've tested this on an LG x220ds.

Then, I've changed the `DataHelper` color suggestions to this values. This caused the suggestions `RecyclerView` to draw fewer children than using shorter names.

```
            sColorSuggestions= new ArrayList<>(Arrays.asList(
                    new ColorSuggestion("GREEN multi line text in tiny screens"),
                    new ColorSuggestion("BLUE multi line text in tiny screens"),
                    new ColorSuggestion("pink"),
                    new ColorSuggestion("purple"),
                    new ColorSuggestion("brown"),
                    new ColorSuggestion("gray"),
                    new ColorSuggestion("Granny Smith Apple"),
                    new ColorSuggestion("Indigo"),
                    new ColorSuggestion("Periwinkle"),
                    new ColorSuggestion("Mahogany"),
                    new ColorSuggestion("Maize"),
                    new ColorSuggestion("Mahogany"),
                    new ColorSuggestion("Outer Space"),
                    new ColorSuggestion("Melon"),
                    new ColorSuggestion("Yellow"),
                    new ColorSuggestion("Orange"),
                    new ColorSuggestion("Red"),
                    new ColorSuggestion("Orchid")));
```

I've also forced to show 10 suggestions every time I type a work by changing the listener to this in `SlidingSearchResultsExampleFragment`:

```
        mSearchView.setOnQueryChangeListener(new FloatingSearchView.OnQueryChangeListener() {

            @Override
            public void onSearchTextChanged(String oldQuery, final String newQuery) {
                mSearchView.swapSuggestions(DataHelper.getHistory(getActivity(), 10));

                Log.d(TAG, "onSearchTextChanged()");
            }
        });

```

### Before the fix
![incorrect_height_calculation](https://user-images.githubusercontent.com/3925897/28413699-e340d616-6d48-11e7-8cae-3faa5ad6e79d.gif)


### After the fix
![correct_height_calculation](https://user-images.githubusercontent.com/3925897/28413708-eb926690-6d48-11e7-86b6-72c22b09f819.gif)
