### PR TITLE
"compile" to "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Usage
 
 1. In your dependencies, add
     ```
-         compile 'com.github.arimorty:floatingsearchview:2.1.1'
+         implementation 'com.github.arimorty:floatingsearchview:2.1.1'
     ```
 2. Add a FloatingSearchView to your view hierarchy, and make sure that it takes
    up the full width and height of the screen


### PR DESCRIPTION
I changed "compile" to "implementation" in README.md, because it's deprecated.

https://developer.android.com/studio/build/dependencies?utm_source=android-studio#dependency_configurations